### PR TITLE
docs: align Craftalism LaTeX documentation with actual repository implementations

### DIFF
--- a/documentation/introduction.tex
+++ b/documentation/introduction.tex
@@ -19,7 +19,7 @@ This architecture allows the economy to be administered, audited, and observed e
 \section*{System Architecture}
 % -----------------------------------------------------------------------------
 
-The platform is composed of five independent services, each in its own repository. All inter-service communication uses HTTP with OAuth2 bearer tokens.
+The platform is composed of five independent services, each in its own repository. Service-to-service communication uses HTTP; the Minecraft plugin authenticates to the Craftalism API with OAuth2 bearer tokens, while the Dashboard currently calls the API without authentication.
 
 \begin{figure}[h]
 \centering
@@ -51,7 +51,7 @@ The platform is composed of five independent services, each in its own repositor
   \item The Minecraft plugin authenticates with the \textbf{Authorization Server} on startup using the \code{client\_credentials} OAuth2 grant, and caches the resulting JWT access token.
   \item All subsequent plugin calls to the \textbf{Craftalism API} carry that JWT as a \code{Bearer} token in the \code{Authorization} header.
   \item The API validates tokens \emph{locally} by fetching the Authorization Server's public keys from \code{/oauth2/jwks} — no per-request round-trip to the auth server is required.
-  \item The \textbf{Dashboard} calls the same API through an Nginx reverse proxy and renders the data for administrators.
+  \item The \textbf{Dashboard} calls the same API through an Nginx reverse proxy and renders the data for administrators; these requests are currently unauthenticated.
   \item Both the API and the Authorization Server persist state to a shared \textbf{PostgreSQL} instance, in separate databases (\code{craftalism} and \code{authserver}).
 \end{enumerate}
 
@@ -81,7 +81,7 @@ The platform is composed of five independent services, each in its own repositor
 The following conventions apply across all modules and are referenced throughout this document.
 
 \begin{itemize}
-  \item \textbf{Authentication:} All API traffic from internal services is authenticated with a short-lived JWT issued via the \code{client\_credentials} grant. Tokens are validated locally using the published JWKS.
+  \item \textbf{Authentication:} The Minecraft plugin authenticates with short-lived JWT access tokens issued via the \code{client\_credentials} grant. The Craftalism API validates these tokens locally using the published JWKS.
   \item \textbf{Error responses:} The API returns RFC 9457 \code{ProblemDetail} payloads for all error conditions, with a consistent set of extension fields: \code{type}, \code{detail}, \code{status}, \code{timestamp}, \code{path}, and \code{errors}.
   \item \textbf{Scope enforcement:} Read operations require the \code{api:read} scope. Write operations require \code{api:write}.
   \item \textbf{Containerization:} All services are distributed as Docker images and orchestrated with Docker Compose via the \code{craftalism-deployment} repository.

--- a/documentation/modules/api.tex
+++ b/documentation/modules/api.tex
@@ -169,7 +169,8 @@ All errors are returned as RFC 9457 \code{ProblemDetail} with the following exte
   \item \code{POST /api/transactions} does not atomically update balances. The ledger and balance state can diverge if the system fails between a balance operation and the subsequent transaction record write.
   \item List endpoints return all records in a single response with no pagination or filtering support. This will degrade under large datasets.
   \item Integration tests run against H2 in-memory, not a real PostgreSQL instance. Schema and query compatibility gaps may exist.
-  \item No CI pipeline is configured.
+  \item CORS allowed origins are hard-coded in \code{SecurityConfig} (localhost ports only), so non-local Dashboard or operator UIs require code changes and rebuilds.
+  \item The repository workflow publishes Docker images on version tags but does not execute automated tests before image publication.
 \end{itemize}
 
 % =============================================================================
@@ -180,5 +181,6 @@ All errors are returned as RFC 9457 \code{ProblemDetail} with the following exte
   \item Integrate \code{POST /api/transactions} with \code{BalanceService.transfer()} so ledger and balance updates occur atomically within a single database transaction.
   \item Add cursor-based or offset pagination and server-side filtering to all list endpoints.
   \item Add integration tests against real PostgreSQL with actual JWT-bearing requests.
-  \item Configure a CI pipeline with lint, typecheck, build, and test stages.
+  \item Externalize allowed origins into environment variables or profile-specific properties.
+  \item Extend the GitHub Actions workflow to run tests before publishing images.
 \end{itemize}

--- a/documentation/modules/authorization_server.tex
+++ b/documentation/modules/authorization_server.tex
@@ -120,8 +120,9 @@ RSA keys are loaded from environment variables (\code{RSA\_PRIVATE\_KEY} / \code
 \begin{itemize}
   \item No \code{generate-keys.sh} script exists in this repository, despite being referenced in documentation and the deployment repository. RSA key pairs must be generated manually.
   \item Integration tests run against H2 in PostgreSQL compatibility mode, not real PostgreSQL. Schema differences may produce false passes.
+  \item \code{SecurityConfig} includes public matchers for \code{/api/**} paths that do not belong to this service and appear to be leftover rules, increasing configuration noise and maintenance risk.
   \item Token introspection and revocation endpoints have no documented usage examples.
-  \item No CI pipeline is configured.
+  \item The repository workflow builds and pushes images on tags but does not run automated tests before publication.
 \end{itemize}
 
 % =============================================================================
@@ -131,6 +132,7 @@ RSA keys are loaded from environment variables (\code{RSA\_PRIVATE\_KEY} / \code
 \begin{itemize}
   \item Add a \code{generate-keys.sh} utility script for RSA key pair generation and formatting.
   \item Add containerized integration tests that run against real PostgreSQL.
+  \item Remove non-auth API path matchers from \code{SecurityConfig} and simplify the fallback chain to auth-server endpoints only.
   \item Document introspection and revocation usage with curl examples.
-  \item Configure a CI pipeline with build and test stages.
+  \item Extend the GitHub Actions workflow to run tests before publishing images.
 \end{itemize}

--- a/documentation/modules/dashboard.tex
+++ b/documentation/modules/dashboard.tex
@@ -87,6 +87,7 @@ In Docker, \code{docker-entrypoint.sh} generates \code{/runtime-config.js} befor
   \item ``Add Player'' and ``Add Balance'' action buttons are UI placeholders; no create flows are implemented or wired to the API.
   \item Sidebar navigation items are presentational only; routing between sections is not implemented.
   \item No automated tests exist for the API client, hooks, or table components.
+  \item The repository workflow builds and publishes Docker images on tags but does not run linting or type checking before publication.
 \end{itemize}
 
 \section{Roadmap}
@@ -96,5 +97,5 @@ In Docker, \code{docker-entrypoint.sh} generates \code{/runtime-config.js} befor
   \item Implement React Router and route-driven navigation for all dashboard sections.
   \item Build create, update, and delete flows for players, balances, and transactions.
   \item Add unit and integration tests for the API client, hooks, and table rendering.
-  \item Add a CI pipeline with lint, typecheck, build, and test stages.
+  \item Extend the GitHub Actions workflow to run linting and type checking before publishing images.
 \end{itemize}

--- a/documentation/modules/economy.tex
+++ b/documentation/modules/economy.tex
@@ -119,6 +119,7 @@ On \code{PlayerJoinEvent}, the plugin calls \code{GET /api/players/\{uuid\}}. If
   \item \code{BootContainer\#shutdown()} is a placeholder and performs no resource cleanup.
   \item \code{/setbalance} input validation accepts numeric digit strings only before scaling; decimal input is rejected inconsistently with other commands.
   \item No integration or end-to-end tests run against a live API instance.
+  \item The release workflow builds with \code{-x test}, so plugin releases are currently published without automated test execution.
 \end{itemize}
 
 \section{Roadmap}
@@ -128,4 +129,5 @@ On \code{PlayerJoinEvent}, the plugin calls \code{GET /api/players/\{uuid\}}. If
   \item Implement \code{BootContainer\#shutdown()} to release HTTP client and cache resources cleanly.
   \item Fix \code{/setbalance} input validation to accept decimal amounts consistently with \code{/pay}.
   \item Add integration tests against a live Craftalism API instance.
+  \item Update the release workflow to execute the test suite before packaging and publishing artifacts.
 \end{itemize}


### PR DESCRIPTION
### Motivation

- Ensure the LaTeX platform documentation exactly reflects the implemented behavior and configuration observed across the repositories, removing inaccurate statements about authentication and CI.
- Surface operational and security-relevant gaps found in code (CORS origins, fallback security matchers, key-generation, and release workflows) so readers can act on real issues rather than assumptions.

### Description

- Update the project introduction to clarify that the Minecraft plugin authenticates via OAuth2 `client_credentials` while the Dashboard currently calls the API unauthenticated.  (modified: `documentation/introduction.tex`).
- Revise the Craftalism API chapter to add observed limitations and roadmap items about hard-coded CORS origins and that Docker images are published on tags without automated test gating.  (modified: `documentation/modules/api.tex`).
- Revise the Authorization Server chapter to document the missing `generate-keys.sh`, H2-vs-Postgres test gap, and an extraneous `SecurityConfig` matcher for `/api/**`, and to recommend CI/workflow changes.  (modified: `documentation/modules/authorization_server.tex`).
- Revise the Economy (plugin) and Dashboard chapters to call out that the plugin release workflow skips tests (`-x test`) and that dashboard image publishing does not run lint/typecheck, and add corresponding roadmap items.  (modified: `documentation/modules/economy.tex`, `documentation/modules/dashboard.tex`).
- No application runtime code was changed; this PR updates only LaTeX documentation files to make the documentation consistent with repository content and CI/workflow observations.

### Testing

- Attempted to compile the documentation with `pdflatex -interaction=nonstopmode -halt-on-error main.tex` inside `documentation/`, but compilation could not be executed because `pdflatex` is not available in this environment (command not found), so a PDF artifact was not produced.
- Verified file modifications and committed the documentation updates with `git` and confirmed repository status; no module unit/integration tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8444b49348323b157fb5edf8168bb)