### PR TITLE
Fix hyperref keyval parsing and make titlesec/titletoc optional

### DIFF
--- a/documentation/preamble.tex
+++ b/documentation/preamble.tex
@@ -44,15 +44,19 @@
 % Hyperlinks and PDF metadata
 % -----------------------------------------------------------------------------
 \usepackage[
-  colorlinks  = true,
-  linkcolor   = CraftAccent,
-  urlcolor    = CraftAccent,
-  citecolor   = CraftAccent,
-  pdftitle    = {Craftalism — Software System Documentation},
-  pdfauthor   = {Henrique Michelini},
-  pdfsubject  = {Technical Documentation},
-  pdfkeywords = {Craftalism, Minecraft, Spring Boot, OAuth2, React}
+  colorlinks = true,
+  linkcolor  = CraftAccent,
+  urlcolor   = CraftAccent,
+  citecolor  = CraftAccent
 ]{hyperref}
+
+% Keep metadata in \hypersetup to avoid comma-splitting in package options.
+\hypersetup{
+  pdftitle   = {Craftalism — Software System Documentation},
+  pdfauthor  = {Henrique Michelini},
+  pdfsubject = {Technical Documentation},
+  pdfkeywords= {Craftalism, Minecraft, Spring Boot, OAuth2, React}
+}
 
 % -----------------------------------------------------------------------------
 % Headers and footers
@@ -82,43 +86,49 @@
 % -----------------------------------------------------------------------------
 % Chapter and section styling
 % -----------------------------------------------------------------------------
-\usepackage{titlesec}
+% titlesec is optional in minimal TeX installs; gracefully fall back to default
+% report class headings when unavailable.
+\IfFileExists{titlesec.sty}{
+  \usepackage{titlesec}
 
-% Chapter: large number + title on two lines with a colored rule
-\titleformat{\chapter}[display]
-  {\normalfont\bfseries\color{CraftBlue}}
-  {\large\textcolor{CraftAccent}{Module \thechapter}}
-  {0pt}
-  {\Huge}
-  [\vspace{2pt}{\color{CraftAccent}\titlerule[1.5pt]}]
+  % Chapter: large number + title on two lines with a colored rule
+  \titleformat{\chapter}[display]
+    {\normalfont\bfseries\color{CraftBlue}}
+    {\large\textcolor{CraftAccent}{Module \thechapter}}
+    {0pt}
+    {\Huge}
+    [\vspace{2pt}{\color{CraftAccent}\titlerule[1.5pt]}]
 
-\titlespacing*{\chapter}{0pt}{-20pt}{24pt}
+  \titlespacing*{\chapter}{0pt}{-20pt}{24pt}
 
-% Section: bold, colored
-\titleformat{\section}
-  {\normalfont\Large\bfseries\color{CraftBlue}}
-  {\thesection}
-  {0.75em}
-  {}
-  [\vspace{2pt}{\color{CraftBorder}\titlerule[0.5pt]}]
+  % Section: bold, colored
+  \titleformat{\section}
+    {\normalfont\Large\bfseries\color{CraftBlue}}
+    {\thesection}
+    {0.75em}
+    {}
+    [\vspace{2pt}{\color{CraftBorder}\titlerule[0.5pt]}]
 
-\titlespacing*{\section}{0pt}{18pt}{8pt}
+  \titlespacing*{\section}{0pt}{18pt}{8pt}
 
-% Subsection: medium, accent color
-\titleformat{\subsection}
-  {\normalfont\large\bfseries\color{CraftGray}}
-  {\thesubsection}
-  {0.75em}
-  {}
+  % Subsection: medium, accent color
+  \titleformat{\subsection}
+    {\normalfont\large\bfseries\color{CraftGray}}
+    {\thesubsection}
+    {0.75em}
+    {}
 
-\titlespacing*{\subsection}{0pt}{12pt}{4pt}
+  \titlespacing*{\subsection}{0pt}{12pt}{4pt}
 
-% Subsubsection: normal size, no number
-\titleformat{\subsubsection}
-  {\normalfont\normalsize\bfseries\color{CraftGray}}
-  {}
-  {0em}
-  {}
+  % Subsubsection: normal size, no number
+  \titleformat{\subsubsection}
+    {\normalfont\normalsize\bfseries\color{CraftGray}}
+    {}
+    {0em}
+    {}
+}{
+  \PackageWarningNoLine{craftalism-doc}{titlesec.sty not found; using default heading styles}
+}
 
 % -----------------------------------------------------------------------------
 % Paragraph spacing
@@ -292,28 +302,32 @@
 % -----------------------------------------------------------------------------
 % Table of contents styling
 % -----------------------------------------------------------------------------
-\usepackage{titletoc}
+\IfFileExists{titletoc.sty}{
+  \usepackage{titletoc}
 
-\titlecontents{chapter}
-  [0em]
-  {\vspace{6pt}\bfseries\color{CraftBlue}}
-  {\contentslabel{2em}}
-  {}
-  {\hfill\contentspage}
+  \titlecontents{chapter}
+    [0em]
+    {\vspace{6pt}\bfseries\color{CraftBlue}}
+    {\contentslabel{2em}}
+    {}
+    {\hfill\contentspage}
 
-\titlecontents{section}
-  [2em]
-  {\small}
-  {\contentslabel{2em}}
-  {}
-  {\titlerule*[6pt]{.}\contentspage}
+  \titlecontents{section}
+    [2em]
+    {\small}
+    {\contentslabel{2em}}
+    {}
+    {\titlerule*[6pt]{.}\contentspage}
 
-\titlecontents{subsection}
-  [4em]
-  {\small\color{CraftGray}}
-  {\contentslabel{2.5em}}
-  {}
-  {\titlerule*[6pt]{.}\contentspage}
+  \titlecontents{subsection}
+    [4em]
+    {\small\color{CraftGray}}
+    {\contentslabel{2.5em}}
+    {}
+    {\titlerule*[6pt]{.}\contentspage}
+}{
+  \PackageWarningNoLine{craftalism-doc}{titletoc.sty not found; using default table of contents formatting}
+}
 
 % -----------------------------------------------------------------------------
 % Miscellaneous utilities


### PR DESCRIPTION
### Motivation
- Comma-separated PDF metadata placed inside `\usepackage[...]{hyperref}` caused keyval parsing to treat words like `Minecraft`, `OAuth2`, `React`, `Spring Boot` as package options, triggering `Package keyval Error` during processing.  
- The preamble unconditionally required `titlesec` and `titletoc`, which fails on minimal TeX installs when those `.sty` files are absent and prevents successful compilation.  

### Description
- Moved PDF metadata (`pdftitle`, `pdfauthor`, `pdfsubject`, `pdfkeywords`) out of `\usepackage[...] {hyperref}` into a dedicated `\hypersetup{...}` block and kept only hyperlink coloring options in `\usepackage{hyperref}` to avoid comma-splitting into package options.  
- Wrapped `titlesec` usage with `\IfFileExists{titlesec.sty}{ ... }{ \PackageWarningNoLine{...}{...} }` so the document falls back to default `report` headings when the package is not installed.  
- Wrapped `titletoc` usage the same way to avoid a second missing-package failure for TOC formatting.  
- Changes are limited to `documentation/preamble.tex` and preserve original enhanced styling when the optional packages are present.  

### Testing
- Ran `cd documentation && latexmk -pdf -interaction=nonstopmode main.tex`, which could not run because `latexmk` is not available in the execution environment, so no full compile was produced.  
- Ran `cd documentation && pdflatex -interaction=nonstopmode main.tex`, which also could not run because `pdflatex` is not available in the execution environment, so no full compile was produced.  
- Verified the preamble edits and patched `documentation/preamble.tex` to implement the `\hypersetup` relocation and `\IfFileExists` guards, and confirmed the changes are limited and targeted to the preamble.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c859ecdf608323a9e1046ee9690637)