### PR TITLE
Fix LaTeX preamble issues causing compilation errors

### DIFF
--- a/documentation/preamble.tex
+++ b/documentation/preamble.tex
@@ -13,7 +13,7 @@
   bottom=2.5cm,
   left=3.0cm,
   right=2.5cm,
-  headheight=14pt
+  headheight=22pt
 ]{geometry}
 
 % -----------------------------------------------------------------------------
@@ -21,6 +21,7 @@
 % -----------------------------------------------------------------------------
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
 \usepackage{lmodern}
 \usepackage{microtype}           % Improved text justification
 
@@ -154,7 +155,7 @@
 % Example: \rowcolors{2}{CraftLight}{white}
 
 % Shared table style macro
-\newcommand{\tableheadstyle}{\rowcolor{CraftBlue}\color{white}\bfseries}
+\newcommand{\tableheadstyle}{\bfseries\color{CraftBlue}}
 
 % -----------------------------------------------------------------------------
 % Code listings
@@ -336,7 +337,7 @@
 \usepackage{amsmath}             % Math (rarely needed, but safe to include)
 
 % Version macro — update in main.tex
-\newcommand{\docversion}{1.0}
+\providecommand{\docversion}{1.0}
 
 % Module badge macro — prints colored label before chapter title description
 \newcommand{\modulelang}[1]{%


### PR DESCRIPTION
### Motivation
- Remove hard LaTeX errors blocking documentation builds, including `\docversion` redefinition, `\babel@toc` undefined control sequence, repeated `Misplaced \noalign` at `\end{tabularx}`, and `fancyhdr` headheight warnings.
- Make the shared preamble safe to include from `main.tex` without redefining project-level macros or injecting table color commands per header cell.

### Description
- Updated `documentation/preamble.tex` to set geometry `headheight` to `22pt` to satisfy `fancyhdr` requirements. 
- Added `\usepackage[english]{babel}` to resolve TOC-related control-sequence issues. 
- Replaced `\newcommand{\docversion}{1.0}` with `\providecommand{\docversion}{1.0}` to avoid redefining the version macro when `main.tex` already defines it. 
- Simplified `\tableheadstyle` to remove `\rowcolor` usage inside each header cell, preventing `Misplaced \noalign` errors with `tabularx` tables.

### Testing
- Ran `cd documentation && latexmk -pdf -interaction=nonstopmode main.tex` and confirmed the previous fatal errors (`\docversion already defined`, `\babel@toc`, and repeated `Misplaced \noalign`) are resolved and a `main.pdf` was produced successfully.
- Observed only standard layout warnings (`Overfull/Underfull \hbox/\vbox`) and normal rerun/reference messages remaining after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c85cc1bd208323ba3cb258506c9764)