### PR TITLE
Hardening: atomic transactions, incident recording, plugin migration, and deployment fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,13 +187,13 @@ The plugin obtains a JWT from the Authorization Server on startup using `client_
 
 ## API Overview
 
-The Craftalism API exposes three resource groups under `/api`. All `GET` endpoints require scope `api:read`; all write endpoints require `api:write`.
+The Craftalism API exposes three resource groups under `/api`. All `GET` endpoints are intentionally public for the dashboard MVP; all write endpoints require `api:write`.
 
 | Resource | Endpoints |
 |---|---|
 | Players | `GET /players`, `GET /players/{uuid}`, `GET /players/name/{name}`, `POST /players` |
 | Balances | `GET /balances`, `GET /balances/{uuid}`, `GET /balances/top`, `POST /balances`, `PUT /balances/{uuid}/set`, `POST /balances/{uuid}/deposit`, `POST /balances/{uuid}/withdraw` |
-| Transactions | `GET /transactions`, `GET /transactions/id/{id}`, `GET /transactions/from/{uuid}`, `GET /transactions/to/{uuid}`, `POST /transactions` |
+| Transactions | `GET /transactions`, `GET /transactions/{id} (legacy alias: /transactions/id/{id})`, `GET /transactions/from/{uuid}`, `GET /transactions/to/{uuid}`, `POST /transactions` |
 
 All error responses conform to RFC 9457 `ProblemDetail`. Full interactive documentation is available at `/api-docs` when the API is running.
 
@@ -201,7 +201,7 @@ All error responses conform to RFC 9457 `ProblemDetail`. Full interactive docume
 
 ## Known Limitations
 
-- `POST /api/transactions` does not atomically update balances. The ledger and balance state can diverge if the plugin fails between the withdrawal and the transaction record write.
+- Incident surfacing is backend-first: incidents are persisted, but there is no dashboard incident view yet.
 - The dashboard has no authentication layer — anyone who can reach port 8080 can view economy data.
 - Dashboard action buttons (Add Player, Add Balance) are UI placeholders; no create flows are implemented.
 - No CI pipeline is configured across any repository.


### PR DESCRIPTION
### Motivation
- Close P0 transfer-integrity gaps identified in the audit by making transfers atomic and auditable.  
- Make critical failures queryable by adding an incident intake so rollback/critical cases are persistently recorded.  
- Eliminate P1 contract drift (transaction detail route + auth/issuer defaults) and apply low-risk P2 polish (deployment script and plugin lifecycle).  

### Description
- API: `TransactionService` now validates sender/receiver, executes `BalanceService.transfer(...)` inside the same `@Transactional` flow and persists the `Transaction` row atomically, `TransactionController` exposes canonical `GET /api/transactions/{id}` and retains a deprecated `/id/{id}` alias with a warning header, and an `incidents` model/repository/service/controller plus Flyway migration (`V6__create_incidents_table.sql`) were added for operational intake.  
- Economy plugin: `PayCommandApplicationService` was migrated to call the API atomic transfer (`TransactionApiService.transfer(...)`) instead of orchestrating withdraw→deposit, an `IncidentApiService` and DTO were added for best-effort incident emission, cache eviction hook was added to `PlayerApplicationService`, `OnQuit` listener was fixed and registered, and `BootContainer`/`ApplicationServiceFactory` now perform deterministic shutdown cache cleanup.  
- Deployment/Auth/Dashboard/Docs: docker-compose and `local|test|prod` scripts were aligned to a canonical internal `AUTH_ISSUER_URI` and include a fail-fast issuer check, the test harness `./test` build path for the economy plugin was fixed to `../craftalism-economy/java`, the auth-server fallback security was tightened to remove irrelevant `/api/**` permits, the dashboard subfolder README was replaced with an authoritative redirect, and root/API docs were updated to reflect the public-read policy and canonical transaction route.  

### Testing
- Unit tests for the API transaction paths were updated (controller/service unit tests adjusted to the new canonical route and atomic behavior) and committed.  
- Attempts to run Gradle compile/test for API, economy and auth modules were made, but execution was blocked by the environment when the Gradle wrapper tried to download distributions (`HTTP/1.1 403 Forbidden` via proxy), so in-container automated test runs could not complete.  
- Manual code inspection and targeted local edits were performed to ensure no broken imports or obvious API contract mismatches were left behind, and Flyway migration for incidents was added for DB compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d03703205883238bb4ac06a0aeb2dc)