### PR TITLE
Formalize cross-repo contracts and standards from ecosystem audit

### DIFF
--- a/contracts/auth-issuer.md
+++ b/contracts/auth-issuer.md
@@ -1,0 +1,58 @@
+# Auth Issuer Contract
+
+## Purpose
+Formalize OAuth2/JWT issuer alignment between authorization server and API resource server so token minting and validation remain interoperable across environments.
+
+## Canonical Rule
+`craftalism-authorization-server` is the sole token issuer for machine clients; `craftalism-api` MUST validate issuer and JWKS against the configured canonical issuer value.
+
+## Owner
+`craftalism-authorization-server` repository (issuer behavior) and `craftalism-api` repository (validation behavior), jointly owned with auth server as source issuer authority.
+
+## Consumers
+- `craftalism-economy` (client credentials token acquisition)
+- `craftalism-api` (JWT resource validation)
+- `craftalism-deployment` (env/default alignment)
+
+## Required Behavior
+- Plugin MUST acquire tokens from `/oauth2/token` using registered machine client credentials.
+- API MUST fail fast on issuer mismatch and reject invalid issuer tokens.
+- Authorization server MUST publish JWKS/discovery endpoints required for API verification.
+- Deployment configs MUST keep issuer URL/host values aligned across services.
+
+## Interface Definition
+- Token endpoint: `/oauth2/token`.
+- Token type/flow: OAuth2 client_credentials.
+- Token verification inputs: issuer URL + JWKS URI (as configured in API resource server settings).
+- Config surfaces include environment variables/profiles in deployment and service configs controlling issuer host resolution.
+
+## Failure Semantics
+- Invalid credentials/client registration errors: token minting denied.
+- Issuer mismatch: API rejects token and request fails (operationally significant incident condition).
+- Ephemeral key rotation/restart risk: tokens may become unverifiable if key persistence is not configured.
+
+## Compatibility Rules
+- Default issuer fallbacks that differ by environment (localhost vs container alias) are transitional and MUST be explicitly documented.
+- No alternate issuer may be introduced without coordinated API validation updates.
+- Legacy or implicit issuer defaults MUST be treated as unsafe unless verified in deployment configuration.
+
+## Observability & Logging
+- Auth server MUST log token issuance failures and client bootstrap issues.
+- API MUST log issuer mismatch failures with enough detail for environment debugging.
+- Deployment runbooks MUST include issuer alignment checks as first-line diagnosis for auth outages.
+
+## Test Expectations
+- Auth server owner MUST maintain token endpoint integration tests.
+- API owner MUST test issuer mismatch rejection and valid-token acceptance.
+- Plugin consumer MUST test token caching/refresh and authenticated call behavior.
+- Cross-repo smoke tests SHOULD validate end-to-end token issuance and API write authorization.
+
+## Documentation Requirements
+- Auth server README MUST document issuer configuration and key persistence caveats.
+- API README MUST document required issuer alignment and troubleshooting guidance.
+- Deployment docs MUST provide concrete env examples for aligned issuer configuration.
+
+## Known Gaps (from audit)
+- Issuer default mismatch risk is explicitly present in deployment configuration patterns.
+- Ephemeral RSA key warning indicates possible operational instability if not persisted.
+- Auth-server policy/config can be conceptually confusing due to `/api/**` references.

--- a/contracts/error-semantics.md
+++ b/contracts/error-semantics.md
@@ -1,0 +1,64 @@
+# Error Semantics Contract
+
+## Purpose
+Normalize cross-repo handling of API/auth failures so consumers behave predictably and operators can diagnose incidents consistently.
+
+## Canonical Rule
+`craftalism-api` error taxonomy and ProblemDetail-style responses define canonical economy error semantics; consumers MUST map and handle these semantics explicitly.
+
+## Owner
+`craftalism-api` repository.
+
+## Consumers
+- `craftalism-economy`
+- `craftalism-dashboard`
+- `craftalism-deployment` (operational interpretation)
+- Root `craftalism` docs
+
+## Required Behavior
+- API MUST return structured errors for validation/security/domain failures.
+- Consumer code MUST not rely on ambiguous string parsing where structured fields exist.
+- Plugin fallback decisions MUST be based on explicit failure classes (e.g., endpoint unavailable) rather than broad catch-all logic.
+- Dashboard MUST surface fetch errors with clear operator-facing states.
+
+## Interface Definition
+- API error model: Spring ProblemDetail/exception-handler driven structure.
+- Expected classes:
+  - Validation/domain violations
+  - Authentication/authorization failures
+  - Idempotency conflicts or transfer conflicts
+  - Unexpected server failures
+- Consumer behavior:
+  - Plugin maps API failures to typed exceptions and command feedback.
+  - Dashboard fetch layer maps HTTP failure to loading/error UI state.
+
+## Failure Semantics
+- Validation errors: request rejected, no state mutation.
+- Transfer conflict/idempotency mismatch: request not duplicated; caller must reconcile by idempotency key/request intent.
+- Auth failures: operation rejected; caller must refresh/reacquire valid token and verify issuer config.
+- Fallback usage in plugin can produce degraded consistency guarantees and MUST be treated as risk-managed path.
+
+## Compatibility Rules
+- Existing inferred error parsing in plugin is tolerated short-term but MUST converge toward explicit structured handling.
+- Error payload structure changes require synchronized consumer updates and release notes.
+- Legacy undocumented error cases MUST be captured in audit/docs before behavior changes.
+
+## Observability & Logging
+- API MUST log exception class/context for operational traceability.
+- Plugin/dashboard MUST log endpoint + status + high-level category for failed requests.
+- Incident records MUST be used for transfer-related failures where implemented by API.
+
+## Test Expectations
+- API owner MUST test exception-to-response mapping for domain, auth, validation, and transfer conflict paths.
+- Plugin consumer MUST test error mapping and fallback trigger conditions.
+- Dashboard consumer MUST test error-state rendering for failed API fetches.
+
+## Documentation Requirements
+- API docs MUST define error categories and expected client action.
+- Plugin/dashboard docs MUST define how user-facing behavior maps from API failures.
+- Cross-repo docs MUST include troubleshooting paths for issuer mismatch and transfer failures.
+
+## Known Gaps (from audit)
+- Plugin has technical debt around inferred error parsing.
+- Cross-repo contract drift raises risk of mismatched failure handling assumptions.
+- CI gaps increase chance that uncoordinated error-contract changes ship undetected.

--- a/contracts/idempotency.md
+++ b/contracts/idempotency.md
@@ -1,0 +1,60 @@
+# Idempotency Contract
+
+## Purpose
+Ensure transfer retries across distributed components do not produce duplicate or inconsistent balance mutations.
+
+## Canonical Rule
+Transfer idempotency is owned and enforced by `craftalism-api`; any client retry behavior MUST preserve idempotency key semantics defined by the API transfer workflow.
+
+## Owner
+`craftalism-api` repository.
+
+## Consumers
+- `craftalism-economy`
+- `craftalism-deployment` (operational retry behavior)
+- Root docs for architecture and operations
+
+## Required Behavior
+- Every transfer request eligible for retry MUST carry consistent idempotency identity.
+- API MUST persist/check idempotency records before applying mutation side effects.
+- Retries with same idempotency identity and equivalent intent MUST not duplicate transfers.
+- Conflicting reuse of idempotency identity with different intent MUST be treated as conflict/failure.
+
+## Interface Definition
+- Write route: `POST /api/balances/transfer`.
+- Idempotency behavior: API transfer endpoint includes idempotency record enforcement (as documented by API and verified in integration tests).
+- Consumer retry context: plugin async command flow and network retries MUST preserve stable idempotency identity through retries.
+
+## Failure Semantics
+- Duplicate retry with same intent: return prior-equivalent outcome/no duplicate mutation.
+- Reuse with mismatch intent: reject as conflict.
+- Missing/invalid idempotency context when retrying: caller risks duplicate semantics and is non-compliant behavior.
+
+## Compatibility Rules
+- Legacy non-idempotent transfer patterns are non-canonical.
+- Fallback transfer paths that bypass canonical idempotent endpoint MUST be documented as degraded compatibility mode.
+- Any idempotency model change requires consumer migration guidance before rollout.
+
+## Observability & Logging
+- API MUST log idempotency collisions/conflicts for incident analysis.
+- Transfer incident recording MUST include context needed to differentiate duplicate retry vs conflicting request.
+- Consumers SHOULD log retry attempts with idempotency correlation metadata where available.
+
+## Test Expectations
+- API owner MUST test:
+  - first-call success,
+  - repeat-call same key same payload,
+  - repeat-call same key conflicting payload,
+  - rollback behavior with idempotency record integrity.
+- Plugin consumer MUST test retry behavior preserves idempotency context.
+- Cross-repo smoke tests SHOULD include induced timeout/retry scenarios.
+
+## Documentation Requirements
+- API docs MUST explicitly define idempotency expectations on transfer operations.
+- Plugin docs MUST explain retry behavior relative to idempotency guarantees.
+- Root architecture docs MUST describe idempotency as a core transfer correctness invariant.
+
+## Known Gaps (from audit)
+- Contract/documentation drift across repos weakens confidence that all clients implement transfer semantics consistently.
+- Plugin fallback complexity can reduce guarantee clarity during endpoint outages.
+- Lack of ecosystem CI gates increases risk of idempotency regressions escaping.

--- a/contracts/incident-recording.md
+++ b/contracts/incident-recording.md
@@ -1,0 +1,54 @@
+# Incident Recording Contract
+
+## Purpose
+Standardize how transfer-related failures are captured so distributed failure modes are auditable and recoverable.
+
+## Canonical Rule
+Transfer incident recording is a required API-side responsibility for failed/exceptional transfer workflows and serves as the canonical operational evidence for transfer-path incidents.
+
+## Owner
+`craftalism-api` repository.
+
+## Consumers
+- `craftalism-economy` (caller context, retry/fallback decisions)
+- `craftalism-deployment` (operations and incident response)
+- Root ecosystem docs (runbooks/architecture)
+
+## Required Behavior
+- API MUST record incident context when transfer processing fails in ways relevant to reconciliation.
+- Incident records MUST be sufficient to correlate request intent, failure class, and retry/idempotency context.
+- Consumers MUST not treat command-level errors as complete without API incident visibility for transfer failures.
+
+## Interface Definition
+- Incident recording occurs within API transfer workflow (`/api/balances/transfer`) as part of transfer correctness controls.
+- Incident data scope (from audit-level behavior): transfer failure metadata and idempotency/transaction context needed for diagnosis.
+- Operational interfaces: logs + persisted incident records exposed via API-side diagnostics tooling/documentation.
+
+## Failure Semantics
+- If transfer mutation fails, incident record MUST still be created whenever failure path reaches recording logic.
+- If incident recording itself fails, this is a critical operational event and MUST be surfaced in service logs.
+- Consumer retries MUST consult transfer/idempotency semantics; incident existence does not imply safe blind replay.
+
+## Compatibility Rules
+- Incident schema evolution MUST preserve core fields used by operations (time, transfer identity, error category/cause).
+- Legacy behavior with incomplete incident detail is tolerated only as documented gap; new changes MUST not reduce detail.
+
+## Observability & Logging
+- API MUST emit structured logs for transfer failures and incident-write outcomes.
+- Deployment runbooks MUST define where operators find incident records and how to correlate with service logs.
+- Plugin logs SHOULD include enough request context to match API incident entries.
+
+## Test Expectations
+- API owner MUST test that transfer failures create incident records.
+- API owner MUST test combined behavior with rollback/idempotency conflict scenarios.
+- Consumer repos SHOULD include tests/assertions ensuring surfaced error metadata supports incident correlation.
+
+## Documentation Requirements
+- API docs MUST document when incident records are written and how they support diagnosis.
+- Deployment docs MUST include incident triage workflow.
+- Root docs MUST describe incident recording as part of transfer reliability posture.
+
+## Known Gaps (from audit)
+- Incident recording is a noted strength but cross-repo governance around its usage is not yet formalized.
+- No ecosystem-wide automated integration pipeline verifies incident paths end-to-end.
+- CI maturity gaps raise risk of silent regressions in failure-path instrumentation.

--- a/contracts/transaction-routes.md
+++ b/contracts/transaction-routes.md
@@ -1,0 +1,63 @@
+# Transaction Routes Contract
+
+## Purpose
+Standardize route ownership and usage for economy reads/writes so all repositories integrate against the same API surface.
+
+## Canonical Rule
+The canonical economy API routes are defined by `craftalism-api`; consumers MUST integrate exactly against those routes and MUST NOT invent parallel route names in docs or code.
+
+## Owner
+`craftalism-api` repository.
+
+## Consumers
+- `craftalism-economy`
+- `craftalism-dashboard`
+- `craftalism-deployment`
+- Root `craftalism` documentation
+
+## Required Behavior
+- Consumers MUST use:
+  - `/api/players`
+  - `/api/balances`
+  - `/api/transactions`
+  - `/api/balances/transfer` (write transfer)
+- Write operations MUST be JWT-authenticated with required scopes.
+- Public-read policy (GET) MUST be treated as current-state behavior and called out as a risk in operational docs.
+- Route changes MUST be announced and synchronized across repos before release.
+
+## Interface Definition
+- Route namespace: `/api/*` served by `craftalism-api`.
+- Auth server token route: `/oauth2/token` (issuer service), consumed by plugin for machine token acquisition.
+- Dashboard API client currently performs unauthenticated reads to API GET endpoints.
+- API validates JWT issuer/JWKS for protected operations.
+
+## Failure Semantics
+- Unknown/incorrect route usage MUST fail as HTTP route errors and be handled as contract violations.
+- Auth failures on protected routes MUST fail request processing and be logged for issuer mismatch diagnosis.
+- Consumer retries MUST preserve idempotency semantics when targeting transfer write route.
+
+## Compatibility Rules
+- `/api/transfers` is legacy/non-canonical documentation and MUST NOT be used for new integrations.
+- Any legacy route references MUST be retained only as migration notes until removed from all docs.
+- Deprecation requires cross-repo PR updates before enforcement.
+
+## Observability & Logging
+- API MUST expose enough request/error observability to identify route mismatch and auth mismatch incidents.
+- Consumers SHOULD log called endpoint and status code for failed operations.
+- Deployment runbooks MUST include route and auth verification checks during incident triage.
+
+## Test Expectations
+- Owner repo MUST cover route-level integration and security policy tests.
+- Plugin consumer MUST test command-to-endpoint mapping and transfer route usage.
+- Dashboard consumer MUST test data fetch behavior against canonical read endpoints.
+- Ecosystem tests SHOULD verify auth token retrieval and route accessibility expectations by environment.
+
+## Documentation Requirements
+- API README is the route source of truth.
+- Plugin/dashboard/root docs MUST mirror route names exactly.
+- Deployment docs MUST reflect service hostnames/ports that resolve these routes correctly.
+
+## Known Gaps (from audit)
+- Cross-repo route naming drift for transfer endpoint.
+- Dashboard auth model and public GET policy create a weak trust boundary.
+- Conceptual confusion from auth-server security config references to `/api/**` despite no such routes in that service.

--- a/contracts/transfer-flow.md
+++ b/contracts/transfer-flow.md
@@ -1,0 +1,60 @@
+# Transfer Flow Contract
+
+## Purpose
+Define the canonical money transfer behavior across plugin, API, and operational documentation so pay operations remain correct, atomic, and diagnosable.
+
+## Canonical Rule
+All balance transfers MUST be executed through the API atomic transfer capability (with idempotency support) as the primary path, with plugin fallback behavior treated as a documented resilience exception when the primary endpoint is unavailable.
+
+## Owner
+`craftalism-api` repository.
+
+## Consumers
+- `craftalism-economy` (Minecraft plugin command execution)
+- `craftalism-dashboard` (reads transfer outcomes via transactions/balances views)
+- `craftalism-deployment` (runtime wiring and env consistency)
+- Root `craftalism` docs (architecture narrative)
+
+## Required Behavior
+- Transfer operations MUST preserve atomicity at API level.
+- Transfer operations MUST enforce idempotency for retried requests.
+- Transfer operations MUST record incidents for failure diagnostics.
+- Plugin pay flow MUST target the canonical API transfer route first.
+- If fallback is used, behavior and compensation risks MUST be explicitly documented as non-atomic relative to canonical transfer.
+
+## Interface Definition
+- Canonical transfer endpoint: `POST /api/balances/transfer`.
+- Related read endpoints used to observe outcomes: `/api/players`, `/api/balances`, `/api/transactions`.
+- Auth model for write operations: OAuth2 client credentials token from auth server, JWT validated by API issuer/JWKS configuration.
+- Idempotency requirement: transfer requests include idempotency key semantics enforced by API transfer logic.
+
+## Failure Semantics
+- Validation/domain errors MUST return structured API error responses (per API exception taxonomy/ProblemDetail handling).
+- Partial write behavior for canonical transfer MUST not occur; API transfer is single-transaction semantics.
+- Retries MUST reuse the same idempotency key to avoid duplicate transfer effects.
+- If plugin fallback path is triggered because transfer endpoint is unavailable, incident risk shifts to compensation consistency; this MUST be treated as degraded mode.
+
+## Compatibility Rules
+- Legacy docs describing a two-step pay pattern are non-canonical and MUST be marked as legacy.
+- References to `/api/transfers` are compatibility drift and MUST be replaced with `/api/balances/transfer`.
+- Backward compatibility expectations: consumers should tolerate existing legacy documentation during migration, but implementation behavior MUST follow canonical route.
+
+## Observability & Logging
+- Transfer attempts and failures MUST be diagnosable through API incident recording.
+- Operational logs SHOULD preserve correlation context (request identifiers/idempotency key where present).
+- Deployment/runtime docs MUST include issuer mismatch troubleshooting because auth failures surface as transfer-path failures.
+
+## Test Expectations
+- Owner repo (`craftalism-api`) MUST test transfer atomicity, rollback behavior, idempotency reuse, and conflict scenarios.
+- Consumer repo (`craftalism-economy`) MUST test primary transfer path usage and fallback trigger behavior.
+- Cross-repo validation SHOULD include compose-based smoke flow: token issuance → transfer call → balance/transaction read verification.
+
+## Documentation Requirements
+- API README MUST define transfer endpoint and semantics as canonical source.
+- Plugin README and root ecosystem docs MUST reference canonical endpoint and describe fallback as degraded behavior.
+- Deployment docs MUST include env alignment notes that affect transfer success (issuer/host consistency).
+
+## Known Gaps (from audit)
+- Documented endpoint drift exists (`/api/transfers` vs `/api/balances/transfer`).
+- Root-level narrative still includes legacy two-step pay description.
+- Fallback complexity can introduce consistency risk during endpoint outages.

--- a/standards/ci-cd.md
+++ b/standards/ci-cd.md
@@ -1,0 +1,56 @@
+# CI/CD Standard
+
+## Purpose
+Establish mandatory quality and release governance for all Craftalism repositories so cross-repo contracts remain reliable.
+
+## Current State (from audit)
+Current pipelines are insufficient for production-grade governance:
+- Most repos emphasize image/release publishing over branch quality verification.
+- PR/push workflows do not consistently enforce lint/typecheck/build/test gates.
+- `craftalism-economy` release workflow skips tests (`build -x test`).
+- No consistent cross-repo integration validation exists before release.
+
+## Required Standard
+No artifact may be released unless automated quality gates pass for the relevant commit.
+All repos MUST run branch-level verification on push and pull request, and release pipelines MUST depend on those checks.
+
+## Minimum Requirements
+- Required on every PR and push to protected branches:
+  - Build/compile job
+  - Automated tests
+  - Lint/static checks (language-appropriate)
+  - Type checks where applicable (e.g., dashboard TypeScript)
+- Required before release/publish:
+  - Re-run or require successful status from quality workflow on the exact commit/tag
+  - Explicit prohibition on test skipping flags
+- Required ecosystem-level check:
+  - Compose-based smoke/integration job validating token issuance + API write/read + dashboard read path
+- Required governance:
+  - Branch protection requiring CI status checks before merge
+  - Failing checks block release automation
+
+## Anti-Patterns (DO NOT DO)
+- Publish-only workflows with no PR quality gates.
+- Releasing artifacts built with tests intentionally disabled.
+- Treating manual local validation as substitute for CI gates.
+- Changing cross-repo contracts without synchronized validation.
+
+## Repository Responsibilities
+- `craftalism-api`: enforce backend test + security test + integration test gates.
+- `craftalism-economy`: enforce unit/integration checks and remove all test-skip release behavior.
+- `craftalism-dashboard`: enforce lint + typecheck + test + build gates.
+- `craftalism-authorization-server`: enforce auth integration and config validation checks.
+- `craftalism-deployment`: enforce compose config validation and smoke deployment checks.
+- Root `craftalism`: maintain ecosystem CI policy documentation and shared contract checklist.
+
+## Enforcement Strategy
+- Add standardized CI workflow templates per repo and mark them as required status checks.
+- Make release workflows dependent on successful quality workflow outputs.
+- Add periodic policy audits (workflow lint/check script) to detect drift.
+- Track compliance via branch protection and failing required checks.
+
+## Known Gaps (from audit)
+- CI quality gates are broadly missing across repos.
+- Economy release currently bypasses tests.
+- Cross-repo integration verification is absent.
+- Current maturity signal is below production-grade engineering governance.

--- a/standards/documentation.md
+++ b/standards/documentation.md
@@ -1,0 +1,52 @@
+# Documentation Standard
+
+## Purpose
+Maintain a synchronized, contract-first documentation layer across repositories so operators and contributors follow the same system truth.
+
+## Current State (from audit)
+- Repo-level READMEs are generally high quality and transparent.
+- Cross-repo drift exists in transfer endpoint naming and flow narrative.
+- Root documentation still includes legacy pay-flow description not aligned with current atomic transfer capability.
+- CI/status descriptions are inconsistent with actual enforcement maturity.
+
+## Required Standard
+Cross-repo contracts MUST be documented consistently with a single canonical source per contract, and all dependent repos MUST mirror that source before release.
+
+## Minimum Requirements
+- Canonical ownership:
+  - API contracts/routes: `craftalism-api` docs are source of truth.
+  - Auth issuer behavior: `craftalism-authorization-server` docs are source of truth.
+  - Deployment env/host alignment: `craftalism-deployment` docs are source of truth.
+- Synchronization requirements:
+  - Any contract change requires same-cycle doc updates in owner + consumer repos.
+  - Root ecosystem docs must reflect current canonical transfer/auth flows.
+- Required contract coverage:
+  - Route names and write/read semantics
+  - Auth issuer/token assumptions
+  - Error semantics, idempotency, incident behavior
+  - CI/testing expectations and known operational caveats
+- Required freshness indicators:
+  - “Known gaps/limitations” sections must remain explicit and current.
+
+## Anti-Patterns (DO NOT DO)
+- Keeping legacy flow descriptions without clear deprecation labeling.
+- Referencing non-canonical endpoints in consumer docs.
+- Claiming CI/test guarantees that workflows do not enforce.
+- Hiding known security/operational limitations.
+
+## Repository Responsibilities
+- Owner repos must publish definitive contract docs and changelog notes for breaking/behavioral changes.
+- Consumer repos must mirror canonical references and remove drift.
+- Root repo must maintain ecosystem-level architecture narrative aligned with current implementation.
+- All repos must document operational troubleshooting for their domain boundaries.
+
+## Enforcement Strategy
+- Add documentation checklist to PR templates for contract-affecting changes.
+- Require doc-drift review item in code review for route/auth/error/CI changes.
+- Add automated link/consistency checks where feasible (endpoint string consistency across docs).
+- Gate releases on presence of synchronized docs for contract changes.
+
+## Known Gaps (from audit)
+- Transfer endpoint and pay-flow description drift across repositories.
+- Inconsistent cross-repo representation of current CI maturity.
+- Conceptual policy confusion in some service docs/config narratives (notably auth/API path expectations).

--- a/standards/testing.md
+++ b/standards/testing.md
@@ -1,0 +1,54 @@
+# Testing Standard
+
+## Purpose
+Define minimum and cross-repo testing expectations so distributed behavior (auth, transfer, retries, routes) remains correct as repositories evolve independently.
+
+## Current State (from audit)
+- `craftalism-api` has strong transfer/security integration coverage.
+- `craftalism-economy` has broad unit tests but limited live-stack E2E evidence.
+- `craftalism-dashboard` has minimal test coverage.
+- `craftalism-authorization-server` has at least token integration test but lighter breadth.
+- `craftalism-deployment` relies mainly on manual operational scripts, not automated integration tests.
+- Testing is not consistently enforced by CI quality gates.
+
+## Required Standard
+Every repository MUST maintain automated tests for its critical responsibilities, and ecosystem contracts MUST be validated through automated cross-repo integration checks.
+
+## Minimum Requirements
+- Service repos (`api`, `authorization-server`):
+  - Unit tests for domain logic
+  - Integration tests for key endpoints/security behavior
+  - Regression tests for known failure modes (issuer mismatch, transfer conflict/idempotency)
+- Consumer repos (`economy`, `dashboard`):
+  - Unit tests for client mapping and error handling
+  - Contract tests for endpoint/route assumptions
+  - Integration/smoke tests against representative API/auth services
+- Deployment repo:
+  - Automated smoke test for compose startup health and basic request path
+- Ecosystem:
+  - End-to-end flow test: obtain token → invoke protected write → verify read model update
+
+## Anti-Patterns (DO NOT DO)
+- Shipping releases when required tests were not executed.
+- Assuming documentation parity implies runtime parity.
+- Relying only on unit tests in contract-sensitive distributed flows.
+- Treating fallback/error paths as optional to test.
+
+## Repository Responsibilities
+- `craftalism-api`: own correctness tests for transfer atomicity, idempotency, rollback, and incident recording.
+- `craftalism-economy`: own command-to-API behavior tests including fallback and retry handling.
+- `craftalism-dashboard`: own fetch/error-state and route-client correctness tests.
+- `craftalism-authorization-server`: own token issuance and issuer config behavior tests.
+- `craftalism-deployment`: own environment startup and inter-service connectivity smoke tests.
+
+## Enforcement Strategy
+- Make testing jobs required status checks for protected branches.
+- Block release jobs unless required test matrix passes.
+- Add cross-repo scheduled/triggered integration pipeline using deployment compose stack.
+- Require test updates when contracts/routes/auth semantics change.
+
+## Known Gaps (from audit)
+- Dashboard and auth-server test breadth is limited compared with API criticality.
+- Economy lacks clear CI-enforced live-stack validation.
+- Deployment has no automated deployment validation pipeline.
+- CI process does not consistently enforce testing across repos.


### PR DESCRIPTION
### Motivation
- The ecosystem audit identified contract drift, CI/CD weakness, and unclear cross-repo responsibilities that reduce reliability and recruiter confidence. 
- This change codifies the audit findings as executable contracts and engineering standards so owners and consumers have a single, auditable source of truth. 
- The goal is normalization and documentation only—no application code or behavior was changed. 

### Description
- Added nine formalized contract and standard documents under `contracts/` and `standards/` reflecting canonical behavior, owners, consumers, interfaces, failure semantics, observability, tests, documentation requirements, and known gaps: `contracts/transfer-flow.md`, `contracts/transaction-routes.md`, `contracts/auth-issuer.md`, `contracts/error-semantics.md`, `contracts/idempotency.md`, `contracts/incident-recording.md`, `standards/ci-cd.md`, `standards/testing.md`, and `standards/documentation.md`. 
- Each contract file follows the mandated schema (`Purpose`, `Canonical Rule`, `Owner`, `Consumers`, `Required Behavior`, `Interface Definition`, `Failure Semantics`, `Compatibility Rules`, `Observability & Logging`, `Test Expectations`, `Documentation Requirements`, `Known Gaps`). 
- The `ci-cd.md` explicitly addresses the audit's CI deficiencies and mandates PR/push quality gates and a prohibition on releasing artifacts without running tests. 
- Changes are documentation-only and committed to the branch for review (no runtime or source code changes were introduced). 

### Testing
- Performed repository-level checks: ran `git status --short` and `git diff --check` to validate workspace state and whitespace/diff issues, and these checks succeeded. 
- Committed the new/updated files via `git commit -m "Formalize ecosystem contracts and engineering standards from audit"` which completed successfully. 
- Reviewed file contents (`cat`/`nl`) to verify the written documents reflect the audit; no automated unit/integration tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1972e64708323b3b9e91b9cca0864)